### PR TITLE
adds configuration for displaying multiple issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pyc
+config.py

--- a/README.md
+++ b/README.md
@@ -40,3 +40,16 @@ you would do this:
 If you choose not to override the core URLs, you will have to change your theme
 to point to the calendar URLs manually, which is not recommended.  Core
 generates URLs for calendar pages in quite a few locations.
+
+Copy `config_example.py` to `config.py`. You may configure whether multiple issues
+on the same day will be identifiable on the calendar with multiple titles. Calendars
+which only display a single title always note where multiple issues were published
+on the same day.
+
+By default, multiples are not distinguished on the calendar with all titles.
+
+```
+# Display where multiple issues occur each day for all issues
+# (multiple issues always show up on calendars for a single title)
+MULTIPLES_ALL_ISSUES = True
+```

--- a/config_example.py
+++ b/config_example.py
@@ -1,0 +1,4 @@
+# Display where multiple issues occur each day for all issues
+# (multiple issues always show up on calendars for a single title)
+MULTIPLES_ALL_ISSUES = False
+

--- a/templates/year_calendar.html
+++ b/templates/year_calendar.html
@@ -31,7 +31,7 @@
                 <td class="noissues">
                   {{day.day_of_month}}
                 </td>
-              {% elif day.issue_count == 1 or not calendar.title %}
+              {% elif day.issue_count == 1 or not display_multiple %}
                 <td class="single">
                   <a href="{{day.link}}">
                     {{day.day_of_month}}

--- a/templates/year_select_form.html
+++ b/templates/year_select_form.html
@@ -6,7 +6,7 @@
       <button id="jump-year">Go</button>
     </div>
   </div>
-  {% if title %}
+  {% if display_multiple %}
   <div class="col-md-7">
     <span class="issues-multiple">
       * Indicates dates with multiple editions

--- a/views.py
+++ b/views.py
@@ -10,11 +10,14 @@ from core.utils.utils import create_crumbs
 
 from issue_calendar import IssueCalendar
 
+from onisite.plugins.calendar import config
+
 @cache_page(settings.DEFAULT_TTL_SECONDS)
 def all_issues_calendar(request, year=None):
     page_title = "Browse All Issues"
     page_name = "issues"
     crumbs = list(settings.BASE_CRUMBS)
+    display_multiple = config.MULTIPLES_ALL_ISSUES
     calendar = IssueCalendar(None, year)
     return render(request, 'all_issues_calendar.html', locals())
 
@@ -23,6 +26,8 @@ def title_issues_calendar(request, lccn, year=None):
     title = get_object_or_404(models.Title, lccn=lccn)
     page_title = "Browse Issues: %s" % title.display_name
     page_name = "issues_title"
+    # always display where a single title has multiple issues on a day
+    display_multiple = True
     crumbs = create_crumbs(title)
     calendar = IssueCalendar(title, year)
     return render(request, 'title_issues_calendar.html', locals())


### PR DESCRIPTION
previously multiple issues per day only shown on
a specific title's calendar
this setting allows installation to display multiple
issues on the calendar page for all titles