### PR TITLE
changes url to view issue instead of first page of issue

### DIFF
--- a/templates/issues_for_date.html
+++ b/templates/issues_for_date.html
@@ -10,7 +10,7 @@
   <ul>
     {% for issue in issues %}
     <li>
-      <a href="{% url 'openoni_page' issue.title.lccn dtstr issue.edition 1 %}">
+      <a href="{% url 'openoni_issue_pages' issue.title.lccn dtstr issue.edition %}">
         {% if not title %}
         {{issue.title.name}} -
         {% endif %}


### PR DESCRIPTION
this matches the behavior of clicking a title specific calendar day
and also will prevent errors from being thrown in the case that an
issue has no pages, but does have a "not digitized" page with some metadata

related to https://github.com/CDRH/open-oni_nebraska_theme/issues/33 although
links from the calendar weren't specifically brought up in that github issue, but I
noticed it while doing some debugging for it

If needed I can share a small batch I have created to test out missing issues